### PR TITLE
Add handshake support for P2P networking

### DIFF
--- a/Documents/Project_PDD.md
+++ b/Documents/Project_PDD.md
@@ -34,6 +34,7 @@ Unity 패키지 매니페스트에 정의된 주요 패키지 버전:
 - **KojeomNet** 라이브러리를 이용해 클라이언트/서버 구조를 구현.
 - 새로 추가된 `PeerToPeerNetwork` 클래스로 P2P 직접 통신 지원.
 - 각 피어는 서버와 클라이언트 역할을 동시에 수행하며, 간단한 브로드캐스트 기능을 제공.
+- 연결 시 간단한 핸드셰이크를 통해 피어 식별 정보를 교환하여 기본 인증 구조를 마련.
 
 ## 5. Testing & Build
 - `dotnet build KojeomNetWorkSpace/KojeomNet/KojeomNet.csproj` 로 네트워크 라이브러리를 빌드.

--- a/KojeomNetWorkSpace/KojeomNet/FrameWork/Soruces/P2PMessage.cs
+++ b/KojeomNetWorkSpace/KojeomNet/FrameWork/Soruces/P2PMessage.cs
@@ -44,6 +44,8 @@ namespace KojeomNet.FrameWork.Soruces
     /// </summary>
     public enum P2PMessageType : byte
     {
+        /// <summary>초기 연결시 서로의 식별 정보를 교환하기 위한 메시지.</summary>
+        Handshake = 0,
         CharacterMovement = 1,
         LevelLoad = 2
     }


### PR DESCRIPTION
## Summary
- introduce Handshake message type for peer identification
- extend PeerToPeerNetwork with handshake sending and event callback
- document handshake in Project PDD

## Testing
- `dotnet build KojeomNetWorkSpace/KojeomNet/KojeomNet.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d32b0460833193f043268c059e09